### PR TITLE
certbot-auto: Print link to doc on debugging pip install error

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -77,8 +77,24 @@ download and run it as follows::
 
 The ``certbot-auto`` command updates to the latest client release automatically.
 Since ``certbot-auto`` is a wrapper to ``certbot``, it accepts exactly
-the same command line flags and arguments. For more information, see 
-`Certbot command-line options <https://certbot.eff.org/docs/using.html#command-line-options>`_.  
+the same command line flags and arguments. For more information, see
+`Certbot command-line options <https://certbot.eff.org/docs/using.html#command-line-options>`_.
+
+Problems with Python virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On a low memory system such as VPS with only 256MB of RAM, the required dependency of Certbot will failed to build. This can be identified if the pip outputs contains something like `internal compiler error: Killed (program cc1)`. You can workaround this restriction by creating a temporary
+swapfile::
+
+  user@webserver:~$ sudo fallocate -l 1G /tmp/swapfile
+  user@webserver:~$ sudo chmod 600 /tmp/swapfile
+  user@webserver:~$ sudo mkswap /tmp/swapfile
+  user@webserver:~$ sudo swapon /tmp/swapfile
+
+Disable and remove the swapfile once the virtual enviroment is constructed::
+
+  user@webserver:~$ sudo swapoff /tmp/swapfile
+  user@webserver:~$ sudo rm /tmp/swapfile
 
 Running with Docker
 ^^^^^^^^^^^^^^^^^^^

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -264,7 +264,18 @@ UNLIKELY_EOF
       # Report error. (Otherwise, be quiet.)
       echo "Had a problem while installing Python packages."
       if [ "$VERBOSE" != 1 ]; then
+        echo
+        echo "pip prints the following errors: "
+        echo "====================================================="
         echo "$PIP_OUT"
+        echo "====================================================="
+        echo
+        echo "Certbot has problem setting up the virtual environment."
+        echo "There maybe some problems with the dependencies, or because "
+        echo "your system has not enough memory to build it."
+        echo
+        echo "Consult https://certbot.eff.org/docs/using.html#problems-with-python-virtual-environment"
+        echo "for possible solutions."
       fi
       rm -rf "$VENV_PATH"
       exit 1


### PR DESCRIPTION
Also, update the doc to teach the user to workaround problem on a low
memory system.

This is a document- and log-only fix.

With instruction here and #3472, we would be able to allow the user to
create automation scripts to do that exact workaround.
